### PR TITLE
Update Readme.md

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -88,7 +88,7 @@ Ensure the following software is installed on your system:
         "METAFLOW_DATATOOLS_S3ROOT": "s3://metaflow-test/data",
         "METAFLOW_DEFAULT_METADATA" : "service",
         "METAFLOW_KUBERNETES_SECRETS": "minio-secret",
-        "METAFLOW_SERVICE_INTERNAL_URL": "http://metaflow-metaflow-service.default.svc.cluster.local:8080",
+        "METAFLOW_SERVICE_URL": "http://metaflow-metaflow-service.default.svc.cluster.local:8080",
         "METAFLOW_AIRFLOW_KUBERNETES_KUBECONFIG_CONTEXT": "minikube"
     }
     ```


### PR DESCRIPTION
Using `METAFLOW_SERVICE_INTERNAL_URL` resulted in:

```
File "/home/thyholt/trymetaflow/.venv/lib/python3.10/site-packages/metaflow/plugins/metadata/service.py", line 49, in __init__
    self.url_task_template = os.path.join(
  File "/usr/lib/python3.10/posixpath.py", line 76, in join
    a = os.fspath(a)
TypeError: expected str, bytes or os.PathLike object, not NoneType
```

when running 

`python helloflow.py airflow create minio-test-dag.py`

From [SERVICE_URL = from_conf("SERVICE_URL")](https://github.com/Netflix/metaflow/blob/9de2ae5efaf3d1410f519323ce3bc558347f971c/metaflow/metaflow_config.py#L215), and changing it to METAFLOW_SERVICE_URL fixed the issue.